### PR TITLE
fix: run urlify on frontend to render links

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "enzyme-adapter-react-16": "^1.14.0",
     "flag-icon-css": "^3.3.0",
     "font-awesome": "^4.7.0",
-    "html-react-parser": "^0.13.0",
     "jest": "^26.0.1",
     "jquery": "^3.5.1",
     "node-sass": "^4.14.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "enzyme-adapter-react-16": "^1.14.0",
     "flag-icon-css": "^3.3.0",
     "font-awesome": "^4.7.0",
+    "html-react-parser": "^0.13.0",
     "jest": "^26.0.1",
     "jquery": "^3.5.1",
     "node-sass": "^4.14.1",

--- a/src/views/Compose/index.js
+++ b/src/views/Compose/index.js
@@ -17,7 +17,7 @@ export default function Compose(props) {
     // if (text.replace('/\n/g', '') === '') return;
     if (msg === '' || msg.replace(/(\r\n|\n|\r)/gm, '') === '') return;
     const reqData = {
-      msg: urlify(msg),
+      msg: msg,
       roomName: props.roomName
     };
     setMsg('');
@@ -34,18 +34,6 @@ export default function Compose(props) {
       .catch((err) => {
         console.log(err);
       });
-  }
-  function urlify(text) {
-    var urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.replace(urlRegex, function (url) {
-      const k =
-        '<a href="' +
-        url +
-        '" style="color: #000000" target="_blank">' +
-        url +
-        '</a>';
-      return k;
-    });
   }
 
   function stoggle() {

--- a/src/views/Message/index.js
+++ b/src/views/Message/index.js
@@ -3,6 +3,18 @@ import moment from 'moment';
 import './Message.css';
 
 export default function Message(props) {
+  function urlify(text) {
+    var urlRegex = /(https?:\/\/[^\s]+)/g;
+    return text.replace(urlRegex, function (url) {
+      const k =
+        '<a href="' +
+        url +
+        '" style="color: #000000" target="_blank">' +
+        url +
+        '</a>';
+      return k;
+    });
+  }
   const { data, isMine, startsSequence, endsSequence, showTimestamp } = props;
   const friendlyTimestamp = moment(data.timestamp).format('LLLL');
   return (
@@ -24,7 +36,7 @@ export default function Message(props) {
             {!isMine && data.sender}
           </b>
           {/* {data.msg} */}
-          <div dangerouslySetInnerHTML={{ __html: data.msg }} />
+          <div dangerouslySetInnerHTML={{ __html: urlify(data.msg) }} />
         </div>
       </div>
     </div>

--- a/src/views/Message/index.js
+++ b/src/views/Message/index.js
@@ -8,15 +8,20 @@ export default function Message(props) {
     const expression = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
     const urlRegex = new RegExp(expression);
     return text.replace(urlRegex, function (url) {
+      let hurl = url;
+      if (!url.includes('http://') && !url.includes('https://')) {
+        hurl = 'https://' + url;
+      }
       const k =
         '<a href="' +
-        url +
-        '" style="color: #000000" target="_blank">' +
+        hurl +
+        '" style="color: #000000" target="_blank" rel="noopener noreferrer">' +
         url +
         '</a>';
       return k;
     });
   }
+
   const { data, isMine, startsSequence, endsSequence, showTimestamp } = props;
   const friendlyTimestamp = moment(data.timestamp).format('LLLL');
   return (

--- a/src/views/Message/index.js
+++ b/src/views/Message/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import moment from 'moment';
 import './Message.css';
+import parse from 'html-react-parser';
 
 export default function Message(props) {
   function urlify(text) {
-    var urlRegex = /(https?:\/\/[^\s]+)/g;
+    const expression = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+    const urlRegex = new RegExp(expression);
     return text.replace(urlRegex, function (url) {
       const k =
         '<a href="' +
@@ -35,8 +37,7 @@ export default function Message(props) {
           <b className={['sendBy', `${isMine}`].join(' ')}>
             {!isMine && data.sender}
           </b>
-          {/* {data.msg} */}
-          <div dangerouslySetInnerHTML={{ __html: urlify(data.msg) }} />
+          <div>{parse(urlify(data.msg))}</div>
         </div>
       </div>
     </div>

--- a/src/views/Message/index.js
+++ b/src/views/Message/index.js
@@ -1,27 +1,30 @@
 import React from 'react';
 import moment from 'moment';
 import './Message.css';
-import parse from 'html-react-parser';
 
 export default function Message(props) {
   function urlify(text) {
-    const expression = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
-    const urlRegex = new RegExp(expression);
-    return text.replace(urlRegex, function (url) {
-      let hurl = url;
-      if (!url.includes('http://') && !url.includes('https://')) {
-        hurl = 'https://' + url;
-      }
-      const k =
-        '<a href="' +
-        hurl +
-        '" style="color: #000000" target="_blank" rel="noopener noreferrer">' +
-        url +
-        '</a>';
-      return k;
-    });
+    const regex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})|[a-zA-Z0-9]+\.[^\s]{2,}/gi;
+    let currentIndex = 0;
+    let match;
+    const returnList = [];
+    while ((match = regex.exec(text))) {
+      returnList.push(text.substring(currentIndex, match.index));
+      const url = text.substring(match.index, match.index + match[0].length);
+      returnList.push(
+        <a
+          href={url.includes('http') ? url : `https://${url}`}
+          target="_blank"
+          style={{ color: '#000000' }}
+          rel="noopener noreferrer">
+          {url}
+        </a>
+      );
+      currentIndex = match.index + match[0].length;
+    }
+    returnList.push(text.substring(currentIndex, text.length));
+    return returnList;
   }
-
   const { data, isMine, startsSequence, endsSequence, showTimestamp } = props;
   const friendlyTimestamp = moment(data.timestamp).format('LLLL');
   return (
@@ -42,7 +45,7 @@ export default function Message(props) {
           <b className={['sendBy', `${isMine}`].join(' ')}>
             {!isMine && data.sender}
           </b>
-          <div>{parse(urlify(data.msg))}</div>
+          <div>{urlify(data.msg)}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Markup is not stored on the database anymore. Urlify runs on the frontend while rendering messages. 
_**Note that this may cause all the old messages to appear in a markup format**_